### PR TITLE
move to django1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.7,<1.8
+Django>=1.8
 psycopg2
 pyelasticsearch
 django-appconf


### PR DESCRIPTION
should we move to django 1.8 given that we've already done it on python-opencivicdata?